### PR TITLE
[Feature]: Support Sequence.prototype.prepend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19001,9 +19001,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.0.tgz",
-      "integrity": "sha512-o8BO3TkMREpAATaFTrXkovMsCpBl2z4NDBoLJuWZcJJj1ijI49UnvDMfVpj+iogn/Jl8Pbhuei5nc/Ti+frEHw==",
+      "version": "24.0.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.2.tgz",
+      "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "semantic-release": "^15.9.16",
     "style-loader": "^0.23.1",
     "travis-deploy-once": "^5.0.9",
-    "ts-jest": "^24.0.0",
+    "ts-jest": "^24.0.2",
     "ts-loader": "^5.3.3",
     "ts-node": "^8.0.3",
     "tslint": "^5.13.1",

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -72,8 +72,8 @@ export class Sequence<TItem> implements Iterable<TItem> {
    * from([1, 2]).concat([3, 4]);
    * ```
    */
-  concat<TOther>(other: Iterable<TOther>): Sequence<TItem | TOther> {
-    return new Sequence(createConcatIterable(this._iterable, other));
+  concat<TOther>(...others: Iterable<TOther>[]): Sequence<TItem | TOther> {
+    return new Sequence(createConcatIterable(this._iterable, ...others));
   }
 
   /**

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -23,6 +23,7 @@ import { createSortByIterable } from "./transforms/sortBy";
 import { createTakeWhileIterable } from "./transforms/takeWhile";
 import { createSkipWhileIterable } from "./transforms/skipWhile";
 import { createWithoutIterable } from "./transforms/without";
+import { createPrependIterable } from "./transforms/prepend";
 
 const identityPredicateFn = (x: any): boolean => x;
 
@@ -554,6 +555,24 @@ export class Sequence<TItem> implements Iterable<TItem> {
     return new Sequence(
       createWithoutIterable(this._iterable, items, predicate)
     );
+  }
+
+  /**
+   * This method yields the elements from the provided items first, followed by the items in the
+   * underlying sequence.
+   *
+   * @param items The provided set of items that should be in the prepended to the Sequence.
+   *
+   * @example
+   * ```ts
+   * // returns [4, 5, 6, 1, 2, 3]
+   * from([1, 2, 3])
+   *   .prepend([4, 5, 6])
+   *   .toArray();
+   * ```
+   */
+  prepend(...items: Iterable<TItem>[]): Sequence<TItem> {
+    return new Sequence(createPrependIterable(this._iterable, ...items));
   }
 
   /**

--- a/src/transforms/concat.ts
+++ b/src/transforms/concat.ts
@@ -2,14 +2,18 @@ import { IterableCreatorIterable } from "../IterableCreatorIterable";
 
 export const createConcatIterable = <TItem, TOther>(
   source: Iterable<TItem>,
-  other: Iterable<TOther>
+  ...others: Iterable<TOther>[]
 ): Iterable<TItem | TOther> =>
-  new IterableCreatorIterable(function* concat(): IterableIterator<TItem | TOther> {
+  new IterableCreatorIterable(function* concat(): IterableIterator<
+    TItem | TOther
+  > {
     for (const item of source) {
       yield item;
     }
 
-    for (const item of other) {
-      yield item;
+    for (const other of others) {
+      for (const item of other) {
+        yield item;
+      }
     }
   });

--- a/src/transforms/prepend.ts
+++ b/src/transforms/prepend.ts
@@ -1,0 +1,19 @@
+import { IterableCreatorIterable } from "../IterableCreatorIterable";
+
+export const createPrependIterable = <TItem, TOther>(
+  source: Iterable<TItem>,
+  ...others: Iterable<TOther>[]
+): Iterable<TItem | TOther> =>
+  new IterableCreatorIterable(function* prepend(): IterableIterator<
+    TItem | TOther
+  > {
+    for (const other of others) {
+      for (const item of other) {
+        yield item;
+      }
+    }
+
+    for (const item of source) {
+      yield item;
+    }
+  });

--- a/test/fromfrom.test.ts
+++ b/test/fromfrom.test.ts
@@ -964,6 +964,14 @@ describe("fromfrom", () => {
     });
   });
 
+  describe("prepend", () => {
+    it("should prepend values to a sequence", () => {
+      const sequence = from([1, 2, 3]).prepend([4, 5, 6]);
+
+      expect(Array.from(sequence)).toStrictEqual([4, 5, 6, 1, 2, 3]);
+    });
+  });
+
   describe("toArray", () => {
     it("returns an array", () => {
       expect(from([1, 2]).toArray()).toEqual([1, 2]);


### PR DESCRIPTION
This pull request adds support for prepending multiple iterable sources to the current source.

It also adds support for multiple sources for the concat function to accept multiple sources.