### PR TITLE
fix: fix object sequences not being iterable more than once

### DIFF
--- a/src/ObjectIterable.ts
+++ b/src/ObjectIterable.ts
@@ -1,15 +1,26 @@
 import { NumberKeyedObject, StringKeyedObject } from "./types";
+import { iterableFromGenerator } from "./utils";
 
 /**
  * Creates an iterable from object, that iterates the object
  * as key value pairs.
  */
-export function createObjectIterable<T>(object: NumberKeyedObject<T>): Iterable<[number, T]>;
-export function createObjectIterable<T>(object: StringKeyedObject<T>): Iterable<[string, T]>;
-export function* createObjectIterable<T>(object: StringKeyedObject<T> | NumberKeyedObject<T>): any {
+export function createObjectIterable<T>(
+  object: NumberKeyedObject<T>
+): Iterable<[number, T]>;
+export function createObjectIterable<T>(
+  object: StringKeyedObject<T>
+): Iterable<[string, T]>;
+export function createObjectIterable<T>(
+  object: StringKeyedObject<T> | NumberKeyedObject<T>
+): any {
+  return iterableFromGenerator(objectIterator, [object]);
+}
+
+function* objectIterator(object: any) {
   for (const key in object) {
     if (object.hasOwnProperty(key)) {
-      const value = (object as any)[key];
+      const value = object[key];
 
       yield [key, value] as any;
     }

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -24,7 +24,7 @@ import { sortBy } from "./transforms/sortBy";
 import { take } from "./transforms/take";
 import { takeWhile } from "./transforms/takeWhile";
 import { without } from "./transforms/without";
-import { copyIntoAnArray } from "./utils";
+import { copyIntoAnArray, iterableFromGenerator } from "./utils";
 
 const identityPredicateFn = (x: any): boolean => x;
 
@@ -39,19 +39,6 @@ const defaultComparer = <TKey>(a: TKey, b: TKey) => {
 
   return 1;
 };
-
-/**
- * Creates an iterable from given generator function
- *
- * @param generatorFn
- * @param args
- */
-const iterableFromGenerator = <TItem>(
-  generatorFn: Function,
-  args?: any
-): Iterable<TItem> => ({
-  [Symbol.iterator]: (): Iterator<TItem> => generatorFn.apply(undefined, args),
-});
 
 /**
  * A sequence of items

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,16 @@ export function copyIntoAnArray<T>(iterable: Iterable<T>) {
 
   return result;
 }
+
+/**
+ * Creates an iterable from given generator function
+ *
+ * @param generatorFn
+ * @param args
+ */
+export const iterableFromGenerator = <TItem>(
+  generatorFn: Function,
+  args?: any[]
+): Iterable<TItem> => ({
+  [Symbol.iterator]: (): Iterator<TItem> => generatorFn.apply(undefined, args),
+});

--- a/test/fromfrom.test.ts
+++ b/test/fromfrom.test.ts
@@ -181,6 +181,13 @@ describe("fromfrom", () => {
 
         expect(from(obj).toArray()).toEqual([["a", 1], ["b", 2]]);
       });
+
+      it("can be iterated multiple times", () => {
+        const sequence = from({ a: 1, b: 2 });
+
+        expect(sequence.toArray()).toEqual([["a", 1], ["b", 2]]);
+        expect(sequence.toArray()).toEqual([["a", 1], ["b", 2]]);
+      });
     });
   });
 


### PR DESCRIPTION
When an object is passed to the from function, it needs to be internally
converted into an iterable so it can be iterated. There was a bug how this
was done, which prevented a Sequence from being iterated more than once.

fix #80