### PR TITLE
feat(groupby): add support to use objects as keys in groupBy

### DIFF
--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -3,6 +3,7 @@ import * as faker from "faker";
 import { from } from "../src/fromfrom";
 
 type Country = "FI" | "SE" | "NO" | "DK" | "IS";
+type Gender = "M" | "F";
 
 interface IUser {
   id: number;
@@ -11,10 +12,12 @@ interface IUser {
   title: string;
   email: string;
   country: Country;
+  gender: Gender;
   score: number;
 }
 
 const countries = ["FI", "SE", "NO", "DK", "IS"] as Country[];
+const genders = ["M", "F"] as Gender[];
 
 const generateData = (howMany: number): IUser[] =>
   Array.from({ length: howMany }).map((_, id) => ({
@@ -24,6 +27,7 @@ const generateData = (howMany: number): IUser[] =>
     title: faker.name.title(),
     email: faker.internet.email(),
     country: faker.random.arrayElement(countries),
+    gender: faker.random.arrayElement(genders),
     score: faker.random.number({ min: 1000, max: 10000 }),
   }));
 
@@ -42,7 +46,15 @@ suite.add("first", () => from(data).first());
 suite.add("flatMap", () => from(data).flatMap(x => [x.firstName, x.lastName]).toArray());
 suite.add("forEach", () => from(data).forEach(x => x.firstName + x.lastName));
 suite.add("groupBy - key selector", () => from(data).groupBy(x => x.country).toArray());
-suite.add("groupBy - value selector", () => from(data).groupBy(x => x.country, x => x.score).toArray());
+suite.add("groupBy - key selector, complex key", () =>
+  from(data)
+    .groupBy(x => ({ c: x.country, g: x.gender }))
+    .toArray());
+suite.add("groupBy - value selector", () =>
+  from(data)
+    .groupBy(x => x.country, x => x.score)
+    .toArray()
+);
 suite.add("includes", () => from(data).includes(data[9823]));
 suite.add("isEmpty", () => from(data).isEmpty());
 suite.add("last", () => from(data).last());

--- a/src/transforms/groupBy.ts
+++ b/src/transforms/groupBy.ts
@@ -5,27 +5,38 @@ export function* groupBy<TItem, TKey, TElement>(
   keySelector: KeySelectorFn<TItem, TKey>,
   elementSelector?: MapFn<TItem, TElement>
 ): IterableIterator<Grouping<TKey, TElement>> {
-  const groups = new Map<TKey, TElement[]>();
+  const groups = new Map<any, { isKeyHashed: boolean; items: TElement[] }>();
 
   for (const item of iterable) {
-    const key = keySelector(item);
+    let key: any = keySelector(item);
+    // Check if we need to hash the key so that equality works correctly
+    // with Map. This is to support object's (and array's) as the key.
+    // We don't want to hash every single item, because it slows down
+    // the algorithm a lot.
+    const needToHash = typeof key === "object";
+    if (needToHash) {
+      key = JSON.stringify(key);
+    }
+
     const value = elementSelector
       ? elementSelector(item)
       : ((item as unknown) as TElement);
 
     let group = groups.get(key);
     if (!group) {
-      group = [];
+      group = { isKeyHashed: needToHash, items: [] };
       groups.set(key, group);
     }
 
-    group.push(value);
+    group.items.push(value);
   }
 
   for (const keyItemsPair of groups.entries()) {
     yield {
-      key: keyItemsPair[0],
-      items: keyItemsPair[1],
+      key: keyItemsPair[1].isKeyHashed
+        ? JSON.parse(keyItemsPair[0])
+        : keyItemsPair[0],
+      items: keyItemsPair[1].items,
     };
   }
 }

--- a/test/fromfrom.test.ts
+++ b/test/fromfrom.test.ts
@@ -360,6 +360,37 @@ describe("fromfrom", () => {
         { key: "F", items: [users[2], users[3]] },
       ]);
     });
+
+    it("groups by an object when an object is given as key", () => {
+      const people = [
+        { name: "John", gender: "M", country: "fi" },
+        { name: "Mike", gender: "M", country: "fi" },
+        { name: "Lisa", gender: "F", country: "fi" },
+        { name: "Mary", gender: "F", country: "se" },
+      ];
+
+      const result = from(people)
+        .groupBy(p => ({ g: p.gender, c: p.country }))
+        .toArray();
+
+      expect(result).toEqual([
+        {
+          key: { g: "M", c: "fi" },
+          items: [
+            { name: "John", gender: "M", country: "fi" },
+            { name: "Mike", gender: "M", country: "fi" },
+          ],
+        },
+        {
+          key: { g: "F", c: "fi" },
+          items: [{ name: "Lisa", gender: "F", country: "fi" }],
+        },
+        {
+          key: { g: "F", c: "se" },
+          items: [{ name: "Mary", gender: "F", country: "se" }],
+        },
+      ]);
+    });
   });
 
   describe("includes", () => {


### PR DESCRIPTION
Internally uses JSON.stringify to "hash" the object and use the hash for equality. I assume this is
sufficient and faster than doing a deep equals check on the object, as JSON.stringify and JSON.parse
are generally fast.

implements #65